### PR TITLE
ADD: optional package manager in spec

### DIFF
--- a/container_generator.py
+++ b/container_generator.py
@@ -80,8 +80,19 @@ def instructions_to_neurodocker_specs(instructions):
     """Return dictionary compatible with Neurodocker given a list of
     instructions.
     """
+    if instructions[0][0] != "base":
+        raise ValueError("first neurodocker instruction must be BASE.")
+    base = instructions[0][1]
+    # 'base' can be a list or tuple with (BASE_IMAGE, APT|YUM).
+    if isinstance(base, (list, tuple)):
+        pkg_manager = base[1]
+        instructions = list(instructions)
+        instructions[0] = base[0]  # Modify "base" instruction in-place.
+        instructions = tuple(instructions)
+    else:
+        pkg_manager = "apt"
     return {
-        "pkg_manager": "apt",
+        "pkg_manager": pkg_manager,
         "check_urls": False,
         "instructions": instructions
     }
@@ -163,6 +174,8 @@ def _generate_dockerfile(dir_, neurodocker_dict, sha1):
     cmd = base_cmd.format(dir=dir_,
                           filepath=basename)
     output = subprocess.check_output(cmd.split())
+    print(output)
+    print("foobar")
     return output.decode()
 
 

--- a/workflowregtest.py
+++ b/workflowregtest.py
@@ -1,17 +1,16 @@
 """Object to orchestrate worflow execution and output tests."""
 
+import ast
 import itertools
 import json, csv
 import os, shutil
 import subprocess
 import tempfile
-import pdb
 from collections import OrderedDict
 from copy import deepcopy
 import matplotlib
 matplotlib.use('agg')
 import matplotlib.pyplot as plt, mpld3
-import numpy as np
 import pandas as pd
 
 import container_generator as cg
@@ -64,7 +63,16 @@ class WorkflowRegtest(object):
         self.soft_str = []
         for ii, specs in enumerate(self.matrix_of_envs):
             self.soft_str.append("_".join([string.split('::')[1].replace(':', '') for string in specs]))
-            self.matrix_of_envs[ii] = [string.split('::') for string in specs]
+            s = [string.split('::') for string in specs]
+
+            # If the package manager is specified along with base image, the
+            # pair is a string type: "['debian:stretch', 'apt']"
+            # Convert that string to a list.
+            base = s[0][1]
+            if "apt" in base or "yum" in base:
+                s[0][1] = ast.literal_eval(base)  # safe eval
+
+            self.matrix_of_envs[ii] = s
 
         # creating additional a dictionary version
         self.matrix_envs_dict = [OrderedDict(mat) for mat in self.matrix_of_envs]

--- a/workflows4regtests/basic_examples/env_test/parameters.json
+++ b/workflows4regtests/basic_examples/env_test/parameters.json
@@ -2,7 +2,7 @@
     "command": "python",
     "env": {
         "base": [
-            "debian:stretch"
+            ["debian:stretch", "apt"]
         ],
         "conda_env_yml": [
             "environment.yml"


### PR DESCRIPTION
The docker base image package manager can be specified as

```json
"base": [
    ["debian:stretch", "apt"]
]
```

If the package manager is not included, it defaults to `apt`, which is current behavior.